### PR TITLE
Use robots' based configuration

### DIFF
--- a/etc/BaselineWalkingController.in.yaml
+++ b/etc/BaselineWalkingController.in.yaml
@@ -256,7 +256,7 @@ OverwriteConfigList:
           wrench:
             linear: [0, 0, 0]
             angular: [0, 0, 0]
-
+robots:
   jvrc1:
     PostureTask:
       jointWeights:


### PR DESCRIPTION
As introduced in https://github.com/jrl-umi3218/mc_rtc/pull/327

This moves robot's specific configuration the robots section of the configuration then:
- we check that values are provided for a given robot (the fully minimal configuration for a given robot is to specify the frame name for the chest orientation task)
- we load this section into the main config
- we load the specified overwrite keys

This was tested on HRP4CR (in simulation) with the configuration introduced by https://github.com/isri-aist/mc_hrp4cr/commit/17175bf3aaa14fab386e3147363cf1eb1a4a2b09

We could get rid of the `ConfigUtils.h` header but I don't know if it's used in other projects downstream