### PR TITLE
Integrate DCM Estimator

### DIFF
--- a/.github/workflows/config/WalkingOnPlaneWaypoint.yaml
+++ b/.github/workflows/config/WalkingOnPlaneWaypoint.yaml
@@ -15,3 +15,7 @@ states:
         waypointList:
           - [0.5, 0.0, 0.0]
           - [0.5, 0.3, 0.0]
+
+CentroidalManager:
+  dcmEstimator:
+    enableDcmEstimator: true

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ https://user-images.githubusercontent.com/6636600/184788709-fcb55fa8-fd93-4be3-b
 
 ## Features
 - Completely open source! (controller framework: mc_rtc, simulator: Choreonoid, sample robot model: JVRC1)
-- Full capabilities, including 3D walking and integration with a footstep planner.
+- Full capabilities, including 3D walking, mass property error compensation of robot model, and integration with a footstep planner.
 - Easy to switch between various methods of centroidal trajectory generation for walking implemented in [CentroidalControlCollection](https://github.com/isri-aist/CentroidalControlCollection).
 - Easy to switch between the two frameworks for centroidal trajectory generation for walking: (1) closed-loop MPC and (2) open-loop MPC + stabilizer.
 - Support for a virtual robot whose model is publicly available so you can try out the controller right away.

--- a/etc/BaselineWalkingController.in.yaml
+++ b/etc/BaselineWalkingController.in.yaml
@@ -199,6 +199,15 @@ CentroidalManager:
       angular: [1.0, 1.0, 1.0]
     regularWeight: 1e-8
     ridgeForceMinMax: [3, 1000] # [N]
+  dcmEstimator:
+    enableDcmEstimator: false
+    dcmCorrectionMode: Bias # "Bias", "Filter", or "None"
+    biasDriftPerSecondStd: 0.002
+    dcmMeasureErrorStd: 0.01
+    zmpMeasureErrorStd: 0.005
+    biasLimit: [0.03, 0.03]
+    initDcmUncertainty: [0.01, 0.01]
+    initBiasUncertainty: [0.01, 0.01]
 
   # PreviewControlZmp
   method: PreviewControlZmp


### PR DESCRIPTION
This PR allows BWC to compensate for the DCM bias estimated by the [LipmDcmEstimator](https://jrl.cnrs.fr/state-observation/doxygen/HEAD/classstateObservation_1_1LipmDcmEstimator.html)

In the video below, the JVRC1 controller model (URDF) is not modified, but only the simulation model (VRML) is mass offset in the lateral direction. Only when the DCM estimator is enabled and the bias is removed, the robot is stable in stepping.  

https://github.com/isri-aist/BaselineWalkingController/assets/6636600/032ddff6-8f94-4293-8983-5f32cccc7d40

